### PR TITLE
Changes related to Dgraph env var; cleanedup nats events from keyphrase

### DIFF
--- a/cmd/ether_graph-server/main.py
+++ b/cmd/ether_graph-server/main.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     # Load ENV variables
     nats_url = getenv("NATS_URL", "nats://localhost:4222")
     dgraph_client_url = getenv(
-        "DGRAPH_URL", "dgraph-0.staging2.internal.etherlabs.io:9080"
+        "DGRAPH_ENDPOINT", "dgraph-0.staging2.internal.etherlabs.io:9080"
     )
 
     # # Initialize dgraph client


### PR DESCRIPTION
## Changes
- Changed Dgraph env var from `DGRAPH_URL` to `DGRAPH_ENDPOINT` as per the comments in https://github.com/etherlabsio/infrastructure/pull/159/files#diff-c74f541241987b0b45d4cfe8d5c97cd3R19
- Cleaned up multiple requests to rec-watchers from keyphrase-service (only request for highlight segments)