### PR TITLE
Recommend non-participants of a meeting

### DIFF
--- a/services/recommendation/utils.py
+++ b/services/recommendation/utils.py
@@ -43,6 +43,8 @@ class Utils(object):
         suggested_user_list,
         word_list,
         segment_users,
+        original_user_score,
+        original_user_names,
         upload=False,
     ):
         segment_obj = req_data["segments"]
@@ -69,6 +71,8 @@ class Utils(object):
                     "contextId": context_id,
                     "instanceId": instance_id,
                     "segmentId": segment_ids,
+                    "originalUsers": original_user_names,
+                    "originalUserScores": original_user_score,
                     "suggestedUsers": suggested_user_list,
                     "userScore": user_scores,
                     "keyphrases": input_keyphrase_list,

--- a/services/recommendation/watcher_utils.py
+++ b/services/recommendation/watcher_utils.py
@@ -2,6 +2,8 @@ import logging
 import json as js
 import pickle
 import math
+import uuid
+from typing import Iterable, List, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -137,3 +139,16 @@ class WatcherUtils(object):
         user_name = self.query_handler.get_user_name(response=response)
 
         return user_name
+
+    def get_active_participants(self, response: List[Dict]) -> List:
+        try:
+            participants = [resp_obj["sourceUserId"] for resp_obj in response]
+            participants = [str(uuid.UUID(u)) for u in participants]
+        except Exception as e:
+            logger.warning(
+                "unable to get participant list",
+                extra={"warn": e, "participantResponse": response},
+            )
+            participants = []
+
+        return participants


### PR DESCRIPTION
This PR changes the way who are suggested. Earlier, users who were not part of the segment were suggested. Now, users who were not part of the meeting will get suggested.

Changes:
- Nats call to get attendees list
- Suggested non-attendees
- Modified validation file to account for the change

Addresses #180 